### PR TITLE
readme: update install instruction + add usage info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,52 @@
 
 ## Installation
 
-	go get -u github.com/tzneal/bincmp
+	go get -u github.com/tzneal/bincmp/cmd/bincmp
+
+## Quick start
+
+It's like `benchstat`, but for binaries.
+
+Given simple "hello world" program:
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+     fmt.Println("Hello")
+}
+```
+
+Compile two binaries with different compile flags:
+
+```
+go build -o old main.go
+go build -o new -ldflags="-w" main.go
+```
+
+Now use `bincmp` to compare binaries:
+
+```
+$ bincmp old new
+binary  delta     old      new
+new     -1183744  2552164  1368420      -46.38%
+
+name               delta     old      new
+.debug_abbrev      -467      467      
+.debug_frame       -74428    74428    
+.debug_gdb_script  -55       55       
+.debug_info        -463938   463938   
+.debug_line        -85159    85159    
+.debug_loc         -388201   388201   
+.debug_pubnames    -32078    32078    
+.debug_pubtypes    -44188    44188    
+.debug_ranges      -92320    92320    
+.shstrtab          -127      267      140      -47.57%
+total              -1180961  1181101  140      -99.99%
+```
+
+If symbols (functions, etc.) have different sizes, output will include additional
+section where old/new symbol sizes are compared.
+Usage scheme remains unchanged: `bincmp a b`.


### PR DESCRIPTION
Without specifying `...` or `cmd/bincmp`, go get will not install the program:
```
$ go get -u github.com/tzneal/bincmp
package github.com/tzneal/bincmp: no Go files in /opt/gotools/src/github.com/tzneal/bincmp
```
But with explicit path it will do the job: `go get -u github.com/tzneal/bincmp/cmd/bincmp`.