### PR TITLE
cmp: fix several issues

### DIFF
--- a/cmp/writer.go
+++ b/cmp/writer.go
@@ -93,7 +93,17 @@ func (s *stdoutWriter) WriteDisassembly(fnA, fnB objdump.Function) error {
 }
 
 func (s *stdoutWriter) WriteSymbol(symA, symB nm.Symbol) error {
-	symName := symA.Name
+	// If it's a symbol that is only present in A or B, we need to
+	// pick a non-empty name here (otherwise we would see an empty name
+	// in a report, which is not helpful).
+	var symName string
+	if symA.Name != "" {
+		symName = symA.Name
+	} else if symB.Name != "" {
+		symName = symB.Name
+	} else {
+		symName = "<?>" // Should never happen
+	}
 	if len(symName) > MaxSymLen {
 		symName = symName[0:MaxSymLen/2] + "..." + symName[len(symName)-MaxSymLen/2-3:]
 	}
@@ -112,7 +122,7 @@ func (s *stdoutWriter) WriteSymbol(symA, symB nm.Symbol) error {
 		s.totals[1] += symA.Size
 	} else if !symB.IsEmpty() {
 		delta := symB.Size
-		fmt.Fprintf(s.w, "%s\t%d\t\t%d\n", symName, delta, symA.Size)
+		fmt.Fprintf(s.w, "%s\t%d\t\t%d\n", symName, delta, symB.Size)
 		s.totals[0] += delta
 		s.totals[2] += symB.Size
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/tzneal/bincmp
+
+go 1.17
+
+require github.com/fatih/color v1.13.0
+
+require (
+	github.com/mattn/go-colorable v0.1.9 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/mattn/go-colorable v0.1.9 h1:sqDoxXbdeALODt0DAeJCVp38ps9ZogZEAXjus69YV3U=
+github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
1. Fix `!symB.IsEmpty()` case for stdoutWriter.WriteSymbol;
   it used symA.Size for the output, which resulted in incorrect (0)
   size of a new symbol. We still computed the correct size,
   but the stdout output was confusing.

2. When symbol is defined only in B, we need to use a name from B,
   otherwise it will be displayed as empty string.
   This is somewhat unhelpful when you want to know where these
   extra bytes in a binary come from.

3. Initialize Go module. This is mostly to make code editing in
   a modern Go environment more convenient.